### PR TITLE
Fix tabpanel bug when user clicks on a tab's child element

### DIFF
--- a/js/tabpanel.js
+++ b/js/tabpanel.js
@@ -189,6 +189,8 @@ if (typeof Object.create !== 'function') {
 
       }, // end _BuildWidget()
       _selectTab: function($item) {
+            $item = $item.closest('[aria-controls]'); // Find tab element if child element clicked
+            
             var $panel = $('#' + $item.attr('aria-controls'));
 
             this.$tabs.attr({ // update tab attributes


### PR DESCRIPTION
Update tabpanel widget to allow child elements inside a tab. Instead of
assuming clicked element is the tab itself (i.e. no children), search
through clicked element's ancestors for an element with an 'aria-controls'
attribute (i.e. the tab element).